### PR TITLE
Content preview logging

### DIFF
--- a/app.go
+++ b/app.go
@@ -41,9 +41,10 @@ func main() {
 		r := mux.NewRouter()
 
 		r.Path("/content-preview/{uuid}").Handler(handlers.MethodHandler{"GET": http.HandlerFunc(handler.contentPreviewHandler)})
-		r.Path("/build-info").Handler(handlers.MethodHandler{"GET": http.HandlerFunc(handler.buildInfoHandler)})
+		r.Path("/build-info").Handler(handlers.MethodHandler{"GET": http.HandlerFunc(buildInfoHandler)})
 		r.Path("/__health").Handler(handlers.MethodHandler{"GET": http.HandlerFunc(fthealth.Handler(*serviceName, serviceDescription, sc.nativeContentSourceCheck(), sc.transformerServiceCheck()))})
 		r.Path("/__ping").Handler(handlers.MethodHandler{"GET": http.HandlerFunc(pingHandler)})
+
 
 		appLogger.ServiceStartedEvent(*serviceName, sc.asMap())
 

--- a/app.go
+++ b/app.go
@@ -3,26 +3,25 @@ package main
 import (
 	fthealth "github.com/Financial-Times/go-fthealth/v1a"
 	"github.com/Financial-Times/http-handlers-go/httphandlers"
-	log "github.com/Sirupsen/logrus"
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
 	"github.com/jawher/mow.cli"
+	"github.com/Sirupsen/logrus"
+	"time"
 	"github.com/rcrowley/go-metrics"
 	"net/http"
 	"os"
-	"time"
 )
 
-const serviceName = "content-preview"
 const serviceDescription = "A RESTful API for retrieving and transforming content to preview data"
 
 var timeout = time.Duration(5 * time.Second)
 var client = &http.Client{Timeout: timeout}
 
 func main() {
-	log.SetLevel(log.InfoLevel)
 
-	app := cli.App(serviceName, serviceDescription)
+	app := cli.App("content-preview", serviceDescription)
+	serviceName :=app.StringOpt("app-name", "content-preview", "The name of this service")
 	appPort := app.StringOpt("app-port", "8084", "Default port for Content Preview app")
 	nativeContentAppAuth := app.StringOpt("source-app-auth", "default", "Basic auth for MAPI")
 	nativeContentAppUri := app.StringOpt("source-app-uri", "http://methode-api-uk-p.svc.ft.com/eom-file/", "URI of the Native Content Source Application endpoint")
@@ -30,31 +29,58 @@ func main() {
 	transformAppHostHeader := app.StringOpt("transform-app-host-header", "methode-article-transformer", "Transform Application Host Header")
 	transformAppUri := app.StringOpt("transform-app-uri", "http://ftapp05951-lvpr-uk-int:8080/content-transform/", "URI of the Transform Application endpoint")
 	transformAppHealthUri := app.StringOpt("transform-app-health-uri", "http://methode-article-transformer-01-pr-uk-int.svc.ft.com/build-info", "URI of the Transform Application health endpoint")
+	sourceAppName := app.StringOpt("source-app-name", "Native Content Service", "Service name of the source application")
+	transformAppName := app.StringOpt("transform-app-name", "Native Content Transformer Service", "Service name of the content transformer application")
 
 	app.Action = func() {
+		appLogger := NewAppLogger()
+		sc := ServiceConfig {*serviceName, *appPort, *nativeContentAppAuth,
+			*transformAppHostHeader, *nativeContentAppUri, *transformAppUri, *nativeContentAppHealthUri, *transformAppHealthUri, *sourceAppName, *transformAppName}
+		handler := Handlers{&sc, appLogger}
+
 		r := mux.NewRouter()
-		handler := Handlers{*nativeContentAppAuth, *transformAppHostHeader, *nativeContentAppUri, *transformAppUri, *nativeContentAppHealthUri, *transformAppHealthUri}
+
 		r.Path("/content-preview/{uuid}").Handler(handlers.MethodHandler{"GET": http.HandlerFunc(handler.contentPreviewHandler)})
 		r.Path("/build-info").Handler(handlers.MethodHandler{"GET": http.HandlerFunc(handler.buildInfoHandler)})
-		r.Path("/__health").Handler(handlers.MethodHandler{"GET": http.HandlerFunc(fthealth.Handler(serviceName, serviceDescription, handler.mapiCheck(), handler.matCheck()))})
-		r.Path("/__ping").Handler(handlers.MethodHandler{"GET": http.HandlerFunc(handler.pingHandler)})
+		r.Path("/__health").Handler(handlers.MethodHandler{"GET": http.HandlerFunc(fthealth.Handler(*serviceName, serviceDescription, sc.nativeContentSourceCheck(), sc.transformerServiceCheck()))})
+		r.Path("/__ping").Handler(handlers.MethodHandler{"GET": http.HandlerFunc(pingHandler)})
 
-		log.WithFields(log.Fields{
-			"source-app-uri":           *nativeContentAppUri,
-			"transform-app-uri":        *transformAppUri,
-			"source-app-health-uri":    *nativeContentAppHealthUri,
-			"transform-app-health-uri": *transformAppHealthUri,
-		}).Infof("%s service started on localhost:%s with configuration", serviceName, *appPort)
+		appLogger.ServiceStartedEvent(*serviceName, sc.asMap())
 
 		err := http.ListenAndServe(":"+*appPort,
 			httphandlers.HTTPMetricsHandler(metrics.DefaultRegistry,
-				httphandlers.TransactionAwareRequestLoggingHandler(log.StandardLogger(), r)))
+				httphandlers.TransactionAwareRequestLoggingHandler(logrus.StandardLogger(), r)))
 
 		if err != nil {
-			log.Fatalf("Unable to start server: %v", err)
+			logrus.Fatalf("Unable to start server: %v", err)
 		}
 	}
-
 	app.Run(os.Args)
+}
 
+type ServiceConfig struct {
+	serviceName 			  string
+	appPort					  string
+	nativeContentAppAuth      string
+	transformAppHostHeader    string
+	nativeContentAppUri       string
+	transformAppUri           string
+	nativeContentAppHealthUri string
+	transformAppHealthUri     string
+	sourceAppName			  string
+	transformAppName 	      string
+}
+
+func (sc ServiceConfig) asMap () map[string] interface{} {
+
+	return map[string] interface{} {
+		"service-name" : sc.serviceName,
+		"service-port" : sc.appPort,
+		"source-app-name" : sc.sourceAppName,
+		"source-app-uri" : sc.nativeContentAppUri,
+		"transform-app-name" : sc.transformAppName,
+		"transform-app-uri"  : sc.transformAppUri,
+		"source-app-health-uri" : sc.nativeContentAppHealthUri,
+		"transform-app-health-uri" : sc.transformAppHealthUri,
+	}
 }

--- a/applogger.go
+++ b/applogger.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"github.com/Sirupsen/logrus"
+	"net/http"
+	tid "github.com/Financial-Times/transactionid-utils-go"
+)
+
+type AppLogger struct {
+	log *logrus.Logger
+}
+
+func NewAppLogger() *AppLogger {
+	logrus.SetLevel(logrus.InfoLevel)
+	log := logrus.New()
+	log.Formatter = new(logrus.JSONFormatter)
+	return &AppLogger{log}
+}
+
+func (appLogger *AppLogger)ServiceStartedEvent(serviceName string, serviceConfig map[string]interface{}) {
+	serviceConfig["event"] = "service_started"
+	appLogger.log.WithFields(serviceConfig).Infof("%s started with configuration", serviceName)
+}
+
+func (appLogger *AppLogger) TransactionStartedEvent(requestUrl string, transactionId string,  uuid string) {
+	appLogger.log.WithFields(logrus.Fields{
+		"event" : "transaction_started",
+		"request_url" : requestUrl,
+		"transaction_id" : transactionId,
+		"uuid" : uuid,
+	}).Info();
+}
+
+func (appLogger *AppLogger) RequestEvent(serviceName string, requestUrl string, transactionId string, uuid string) {
+	appLogger.log.WithFields(logrus.Fields{
+		"event" : "request",
+		"service_name" : serviceName,
+		"request_uri" : requestUrl,
+		"transaction_id" : transactionId,
+		"uuid" : uuid,
+	}).Info();
+}
+
+func (appLogger *AppLogger) ErrorEvent(serviceName string, requestUrl string, transactionId string, err error, uuid string) {
+	appLogger.log.WithFields(logrus.Fields{
+		"event": "error",
+		"service_name" : serviceName,
+		"request_url": requestUrl,
+		"transaction_id" : transactionId,
+		"error" : err,
+		"uuid" : uuid,
+	}).
+	Warnf("Cannot reach %s host", serviceName)
+
+}
+func (appLogger *AppLogger) RequestFailedEvent(serviceName string, requestUrl string, resp *http.Response,  uuid string) {
+	appLogger.log.WithFields(logrus.Fields{
+		"event": "request_failed",
+		"service_name" : serviceName,
+		"request_url": requestUrl,
+		"transaction_id" : resp.Header.Get(tid.TransactionIDHeader),
+		"status" : resp.StatusCode,
+		"uuid" : uuid,
+	}).
+	Warnf("Request failed. %s responded with %s", serviceName, resp.Status)
+}
+
+func (appLogger *AppLogger) ResponseEvent(serviceName string, requestUrl string, resp *http.Response,  uuid string) {
+	appLogger.log.WithFields(logrus.Fields {
+		"event" : "response",
+		"service_name" : serviceName,
+		"status" : resp.StatusCode,
+		"request_url": requestUrl,
+		"transaction_id" : resp.Header.Get(tid.TransactionIDHeader),
+		"uuid" : uuid,
+	}).
+	Info("Response from " + serviceName)
+}
+

--- a/handlers.go
+++ b/handlers.go
@@ -2,9 +2,8 @@ package main
 
 import (
 	"fmt"
-	tid "github.com/Financial-Times/transactionid-utils-go"
-	log "github.com/Sirupsen/logrus"
 	"github.com/gorilla/mux"
+	tid "github.com/Financial-Times/transactionid-utils-go"
 	"golang.org/x/net/context"
 	"io"
 	"net/http"
@@ -12,18 +11,12 @@ import (
 
 const uuidKey = "uuid"
 
-var logger = log.New()
-
 type Handlers struct {
-	nativeContentAppAuth      string
-	transformAppHostHeader    string
-	nativeContentAppUri       string
-	transformAppUri           string
-	nativeContentAppHealthUri string
-	transformAppHealthUri     string
+	serviceConfig *ServiceConfig
+	log           *AppLogger
 }
 
-func (h Handlers) pingHandler(w http.ResponseWriter, r *http.Request) {
+func pingHandler(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "pong")
 }
 
@@ -32,14 +25,10 @@ func (h Handlers) buildInfoHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h Handlers) contentPreviewHandler(w http.ResponseWriter, r *http.Request) {
-	logger.Formatter = new(log.JSONFormatter)
-	logger.WithFields(log.Fields{
-		"requestUri":    r.RequestURI,
-		"transactionId": tid.GetTransactionIDFromRequest(r),
-	}).Info("request started")
-
 	vars := mux.Vars(r)
 	uuid := vars["uuid"]
+
+	h.log.TransactionStartedEvent(r.RequestURI, tid.GetTransactionIDFromRequest(r), uuid)
 
 	ctx := tid.TransactionAwareContext(context.Background(), r.Header.Get(tid.TransactionIDHeader))
 	ctx = context.WithValue(ctx, uuidKey, uuid)
@@ -58,72 +47,73 @@ func (h Handlers) contentPreviewHandler(w http.ResponseWriter, r *http.Request) 
 	matResp.Body.Close()
 }
 
-func (h Handlers) getNativeContent(ctx context.Context, w http.ResponseWriter) (ok bool, resp *http.Response) {
-	logger.Formatter = new(log.JSONFormatter)
+func ( h Handlers) getNativeContent(ctx context.Context, w http.ResponseWriter) (ok bool, resp *http.Response) {
 	uuid := ctx.Value(uuidKey).(string)
-	requestUrl := fmt.Sprintf("%s%s", h.nativeContentAppUri, uuid)
+	requestUrl := fmt.Sprintf("%s%s", h.serviceConfig.nativeContentAppUri, uuid)
 
 	transactionId, _ := tid.GetTransactionIDFromContext(ctx)
-	logger.WithFields(log.Fields{
-		"requestUri":    requestUrl,
-		"transactionId": transactionId,
-	}).Info("Request to MAPI")
+	h.log.RequestEvent(h.serviceConfig.sourceAppName, requestUrl, transactionId, uuid)
 
 	req, err := http.NewRequest("GET", requestUrl, nil)
 
 	req.Header.Set(tid.TransactionIDHeader, transactionId)
-	req.Header.Set("Authorization", "Basic "+h.nativeContentAppAuth)
+	req.Header.Set("Authorization", "Basic " + h.serviceConfig.nativeContentAppAuth)
 	req.Header.Set("Content-Type", "application/json")
 	resp, err = client.Do(req)
 
 	//this happens when hostname cannot be resolved or host is not accessible
-	if err != nil {
-		log.WithFields(log.Fields{"error": err, "transactionId": req.Header.Get(tid.TransactionIDHeader)}).Warnf("Cannot reach MAPI host")
+	if err !=nil {
+		h.log.ErrorEvent(h.serviceConfig.sourceAppName, req.URL.String(), req.Header.Get(tid.TransactionIDHeader), err, uuid)
 		w.WriteHeader(http.StatusServiceUnavailable)
 		return false, nil
 	}
 	if resp.StatusCode != http.StatusOK {
-		w.WriteHeader(http.StatusNotFound)
-		log.WithFields(log.Fields{"MAPI.Status": resp.StatusCode, "transactionId": resp.Header.Get(tid.TransactionIDHeader)}).Warnf("Request to MAPI failed")
+		w.WriteHeader(http.StatusNotFound);
+		h.log.RequestFailedEvent(h.serviceConfig.sourceAppName, req.URL.String(), resp, uuid)
 		return false, nil
 	}
-	logger.WithFields(log.Fields{"status": resp.Status, "transactionId": resp.Header.Get(tid.TransactionIDHeader)}).Info("Response from MAPI")
+	h.log.ResponseEvent(h.serviceConfig.sourceAppName, req.URL.String(), resp, uuid)
 	return true, resp
 }
 
-func (h Handlers) getTransformedContent(ctx context.Context, mapiResp http.Response, w http.ResponseWriter) (ok bool, resp *http.Response) {
-	logger.Formatter = new(log.JSONFormatter)
+func ( h Handlers) getTransformedContent(ctx context.Context, mapiResp http.Response, w http.ResponseWriter) (ok bool, resp *http.Response) {
 	uuid := ctx.Value(uuidKey).(string)
-	requestUrl := fmt.Sprintf("%s%s?preview=true", h.transformAppUri, uuid)
+	requestUrl := fmt.Sprintf("%s%s?preview=true", h.serviceConfig.transformAppUri, uuid)
 	transactionId, _ := tid.GetTransactionIDFromContext(ctx)
 
-	//TODO we need to assert that mapiResp.Header.Get(tid.TransactionIDHeader) ==  transactionId
+	//TODO we need to assert that resp.Header.Get(tid.TransactionIDHeader) ==  transactionId
 	//to ensure that we are logging exactly what is actually passed around in the headers
-	logger.WithFields(log.Fields{
-		"requestUri":    requestUrl,
-		"transactionId": transactionId,
-	}).Info("Request to MAT")
+
+	h.log.RequestEvent(h.serviceConfig.transformAppName, requestUrl, transactionId, uuid)
 
 	req, err := http.NewRequest("POST", requestUrl, mapiResp.Body)
-	req.Host = h.transformAppHostHeader
+	req.Host = h.serviceConfig.transformAppHostHeader
 	req.Header.Set(tid.TransactionIDHeader, transactionId)
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err = client.Do(req)
 
 	//this happens when hostname cannot be resolved or host is not accessible
-	if err != nil {
-		log.WithFields(log.Fields{"error": err, "transactionId": transactionId}).Warnf("Cannot reach MAT host")
-		w.WriteHeader(http.StatusServiceUnavailable)
+
+	if err !=nil {
+		h.log.ErrorEvent(h.serviceConfig.transformAppName, req.URL.String(), req.Header.Get(tid.TransactionIDHeader), err, uuid)
+
 		return false, nil
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		w.WriteHeader(http.StatusNotFound)
-		log.WithFields(log.Fields{"MAT.Status": resp.StatusCode, "transactionId": transactionId}).Warnf("Request to MAT failed")
+
+		w.WriteHeader(http.StatusNotFound);
+		h.log.RequestFailedEvent(h.serviceConfig.transformAppName, req.URL.String(), resp, uuid)
 		return false, nil
 	}
 
-	logger.WithFields(log.Fields{"status": resp.Status, "requestUrl": req.URL.String(), "transactionId": transactionId}).Info("Response from MAT")
+	h.log.ResponseEvent(h.serviceConfig.transformAppName, req.URL.String(), resp, uuid)
+
 	return true, resp
 }
+
+
+
+
+

--- a/handlers.go
+++ b/handlers.go
@@ -20,7 +20,7 @@ func pingHandler(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "pong")
 }
 
-func (h Handlers) buildInfoHandler(w http.ResponseWriter, r *http.Request) {
+func buildInfoHandler(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "build-info")
 }
 

--- a/healthchecks.go
+++ b/healthchecks.go
@@ -5,28 +5,28 @@ import (
 	fthealth "github.com/Financial-Times/go-fthealth/v1a"
 )
 
-func (h Handlers) mapiCheck() fthealth.Check {
+func (sc *ServiceConfig) nativeContentSourceCheck() fthealth.Check {
 	return fthealth.Check{
 		BusinessImpact:   "Editorial users won't be able to preview articles",
-		Name:             "Methode Api Availabililty Check",
+		Name:             sc.sourceAppName + " Availabililty Check",
 		PanicGuide:       "TODO - write panic guide",
 		Severity:         1,
-		TechnicalSummary: "Checks that Methode API Service is reachable. Article Preview Service requests native content from Methode API service.",
+		TechnicalSummary: "Checks that " + sc.sourceAppName + " Service is reachable. Article Preview Service requests native content from " + sc.sourceAppName + " service.",
 		Checker:          func() (string, error) {
-			return checkServiceAvailability("Methode API", h.nativeContentAppHealthUri, h.nativeContentAppAuth, "")
+			return checkServiceAvailability(sc.sourceAppName, sc.nativeContentAppHealthUri, sc.nativeContentAppAuth, "")
 		},
 	}
 }
 
-func (h Handlers) matCheck() fthealth.Check {
+func (sc *ServiceConfig) transformerServiceCheck() fthealth.Check {
 	return fthealth.Check {
 		BusinessImpact:   "Editorial users won't be able to preview articles",
-		Name:             "Methode Article Transformer Availabililty Check",
+		Name:             sc.transformAppName + " Availabililty Check",
 		PanicGuide:       "TODO - write panic guide",
 		Severity:         1,
-		TechnicalSummary: "Checks that Methode Article Transformer Service is reachable. Article Preview Service relies on Methode Article Transformer service to process content.",
+		TechnicalSummary: "Checks that " + sc.transformAppName + " Service is reachable. Article Preview Service relies on "+ sc.transformAppName + " service to process content.",
 		Checker:          func() (string, error) {
-			return checkServiceAvailability("Methode Article Transformer", h.transformAppHealthUri, "", h.transformAppHostHeader)
+			return checkServiceAvailability(sc.transformAppName, sc.transformAppHealthUri, "", sc.transformAppHostHeader)
 		},
 	}
 }


### PR DESCRIPTION
Massive improvements to application structure
1. decoupled Handlers and ServiceConfiguration as 2 distinct structs
2. realised that not only application configuration properties, but also logging messages and healthchecks are tied to MAT & MAPI names. If we want to re-use content-preview for Wordpress this will not be very pretty, So, I had to generalise those as well.
3. logging code was cluttering the application code, so extracted it into an ApplicationLogger struct
4. after looking at the logs in splunk I devised a better logging format for application logs as "Event Logging" - the idea being that an application produces events that we log.
