### PR TITLE
Fixed Dockerfile to create proper build-info with DockerHub

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,9 @@ RUN apk --update add git bzr \
   && export GOPATH=/gopath \
   && REPO_PATH="github.com/Financial-Times/content-preview" \
   && git clone /content-preview/ $GOPATH/src/${REPO_PATH} \
+  && ls $GOPATH/src/${REPO_PATH} \
   && cd $GOPATH/src/${REPO_PATH} \
+  && git fetch \
   && go get -t ./... \
   && go test ./... \
   && BUILDINFO_PACKAGE="github.com/Financial-Times/service-status-go/buildinfo." \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.3
 
 ADD *.go .git /content-preview/
 
-RUN apk --update add bash git go \
+RUN apk --update add git go \
   && export GOPATH=/gopath \
   && REPO_PATH="github.com/Financial-Times/content-preview" \
   && cd content-preview \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apk --update add bash git go \
   && export GOPATH=/gopath \
   && REPO_PATH="github.com/Financial-Times/content-preview" \
   && cd content-preview \
-  && git fetch --all \
+  && git fetch --all --tags \
   && BUILDINFO_PACKAGE="github.com/Financial-Times/service-status-go/buildinfo." \
   && VERSION="version=$(git describe --tag --always 2> /dev/null)" \
   && DATETIME="dateTime=$(date -u +%Y%m%d%H%M%S)" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ RUN apk --update add bash git go \
   && export GOPATH=/gopath \
   && REPO_PATH="github.com/Financial-Times/content-preview" \
   && cd content-preview \
-  && git fetch --all --tags \
   && BUILDINFO_PACKAGE="github.com/Financial-Times/service-status-go/buildinfo." \
   && VERSION="version=$(git describe --tag --always 2> /dev/null)" \
   && DATETIME="dateTime=$(date -u +%Y%m%d%H%M%S)" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,15 @@ RUN apk --update add git bzr \
   && go test ./... \
   && BUILDINFO_PACKAGE="github.com/Financial-Times/service-status-go/buildinfo." \
   && VERSION="version=$(git describe --tag 2> /dev/null)" \
+  && echo $VERSION \
   && DATETIME="dateTime=$(date -u +%Y%m%d%H%M%S)" \
+  && echo $DATETIME \
   && REPOSITORY="repository=$(git config --get remote.origin.url)" \
+  && echo $REPOSITORY \
   && REVISION="revision=$(git rev-parse HEAD)" \
+  && echo $REVISION \
   && BUILDER="builder=$(go version)" \
+  && echo $BUILDER \
   && LDFLAGS="-X '"${BUILDINFO_PACKAGE}$VERSION"' -X '"${BUILDINFO_PACKAGE}$DATETIME"' -X '"${BUILDINFO_PACKAGE}$REPOSITORY"' -X '"${BUILDINFO_PACKAGE}$REVISION"' -X '"${BUILDINFO_PACKAGE}$BUILDER"'" \
   && echo ${LDFLAGS} \
   && go build -ldflags="${LDFLAGS}" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,11 @@ FROM alpine:3.3
 
 ADD *.go .git /content-preview/
 
-RUN apk --update add git go \
+RUN apk --update add bash git go \
   && export GOPATH=/gopath \
   && REPO_PATH="github.com/Financial-Times/content-preview" \
   && cd content-preview \
-  && git fetch \
+  && git fetch --tags \
   && git describe --tag \
   && BUILDINFO_PACKAGE="github.com/Financial-Times/service-status-go/buildinfo." \
   && VERSION="version=$(git describe --tag 2> /dev/null)" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,13 @@ FROM alpine:3.3
 
 ADD *.go *.txt .git /content-preview/
 
-RUN apk --update add git bzr openssh-client \
+RUN apk --update add git bzr \
   && apk --update add go \
   && export GOPATH=/gopath \
   && REPO_PATH="github.com/Financial-Times/content-preview" \
   && cd /content-preview/ \
   && GIT_URL="$(git config --get remote.origin.url)" \
   && GIT_BRANCH="$(git rev-parse --abbrev-ref HEAD)" \
-  && echo $GIT_BRANCH \
   && git clone -b $GIT_BRANCH $GIT_URL $GOPATH/src/${REPO_PATH} \
   && ls $GOPATH/src/${REPO_PATH} \
   && cd $GOPATH/src/${REPO_PATH} \
@@ -17,20 +16,14 @@ RUN apk --update add git bzr openssh-client \
   && go test ./... \
   && BUILDINFO_PACKAGE="github.com/Financial-Times/service-status-go/buildinfo." \
   && VERSION="version=$(git describe --tag 2> /dev/null)" \
-  && echo $VERSION \
   && DATETIME="dateTime=$(date -u +%Y%m%d%H%M%S)" \
-  && echo $DATETIME \
   && REPOSITORY="repository=$GIT_URL" \
-  && echo $REPOSITORY \
   && REVISION="revision=$(git rev-parse HEAD)" \
-  && echo $REVISION \
   && BUILDER="builder=$(go version)" \
-  && echo $BUILDER \
   && LDFLAGS="-X '"${BUILDINFO_PACKAGE}$VERSION"' -X '"${BUILDINFO_PACKAGE}$DATETIME"' -X '"${BUILDINFO_PACKAGE}$REPOSITORY"' -X '"${BUILDINFO_PACKAGE}$REVISION"' -X '"${BUILDINFO_PACKAGE}$BUILDER"'" \
-  && echo ${LDFLAGS} \
   && go build -ldflags="${LDFLAGS}" \
   && mv content-preview /content-preview-app \
-  && apk del go git bzr openssh-client \
+  && apk del go git bzr \
   && rm -rf $GOPATH /var/cache/apk/*
 
 CMD exec /content-preview-app \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ RUN apk --update add git go \
   && export GOPATH=/gopath \
   && REPO_PATH="github.com/Financial-Times/content-preview" \
   && cd content-preview \
+  && git fetch \
+  && git describe --tag \
   && BUILDINFO_PACKAGE="github.com/Financial-Times/service-status-go/buildinfo." \
   && VERSION="version=$(git describe --tag 2> /dev/null)" \
   && DATETIME="dateTime=$(date -u +%Y%m%d%H%M%S)" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ RUN apk --update add git bzr openssh-client \
   && cd /content-preview/ \
   && GIT_URL="$(git config --get remote.origin.url)" \
   && GIT_BRANCH="$(git rev-parse --abbrev-ref HEAD)" \
-  && echo GIT_BRANCH \
-  && git clone $GIT_URL -b $GOPATH/src/${REPO_PATH} \
+  && echo $GIT_BRANCH \
+  && git clone -b $GIT_BRANCH $GIT_URL $GOPATH/src/${REPO_PATH} \
   && ls $GOPATH/src/${REPO_PATH} \
   && cd $GOPATH/src/${REPO_PATH} \
   && go get -t ./... \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,27 +2,26 @@ FROM alpine:3.3
 
 ADD *.go .git /content-preview/
 
-RUN apk --update add git bzr \
-  && apk --update add go \
+RUN apk --update add git go \
   && export GOPATH=/gopath \
   && REPO_PATH="github.com/Financial-Times/content-preview" \
-  && cd /content-preview/ \
-  && GIT_URL="$(git config --get remote.origin.url)" \
-  && GIT_BRANCH="$(git rev-parse --abbrev-ref HEAD)" \
-  && git clone -b $GIT_BRANCH $GIT_URL $GOPATH/src/${REPO_PATH} \
-  && cd $GOPATH/src/${REPO_PATH} \
-  && go get -t ./... \
-  && go test ./... \
+  && cd content-preview \
   && BUILDINFO_PACKAGE="github.com/Financial-Times/service-status-go/buildinfo." \
   && VERSION="version=$(git describe --tag 2> /dev/null)" \
   && DATETIME="dateTime=$(date -u +%Y%m%d%H%M%S)" \
-  && REPOSITORY="repository=$GIT_URL" \
+  && REPOSITORY="repository=$(git config --get remote.origin.url)" \
   && REVISION="revision=$(git rev-parse HEAD)" \
   && BUILDER="builder=$(go version)" \
   && LDFLAGS="-X '"${BUILDINFO_PACKAGE}$VERSION"' -X '"${BUILDINFO_PACKAGE}$DATETIME"' -X '"${BUILDINFO_PACKAGE}$REPOSITORY"' -X '"${BUILDINFO_PACKAGE}$REVISION"' -X '"${BUILDINFO_PACKAGE}$BUILDER"'" \
+  && echo $LDFLAGS \
+  && mkdir -p $GOPATH/src/${REPO_PATH} \
+  && mv * $GOPATH/src/${REPO_PATH} \
+  && cd $GOPATH/src/${REPO_PATH} \
+  && go get -t ./... \
+  && go test ./... \
   && go build -ldflags="${LDFLAGS}" \
   && mv content-preview /content-preview-app \
-  && apk del go git bzr \
+  && apk del go git \
   && rm -rf $GOPATH /var/cache/apk/*
 
 CMD exec /content-preview-app \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,6 @@ RUN apk --update add git bzr openssh-client \
   && git clone $GIT_URL $GOPATH/src/${REPO_PATH} \
   && ls $GOPATH/src/${REPO_PATH} \
   && cd $GOPATH/src/${REPO_PATH} \
-  && git fetch \
   && go get -t ./... \
   && go test ./... \
   && BUILDINFO_PACKAGE="github.com/Financial-Times/service-status-go/buildinfo." \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,8 @@ RUN apk --update add bash git go \
   && export GOPATH=/gopath \
   && REPO_PATH="github.com/Financial-Times/content-preview" \
   && cd content-preview \
-  && git fetch --tags \
-  && git describe --tag \
   && BUILDINFO_PACKAGE="github.com/Financial-Times/service-status-go/buildinfo." \
-  && VERSION="version=$(git describe --tag 2> /dev/null)" \
+  && VERSION="version=$(git describe --tag --always 2> /dev/null)" \
   && DATETIME="dateTime=$(date -u +%Y%m%d%H%M%S)" \
   && REPOSITORY="repository=$(git config --get remote.origin.url)" \
   && REVISION="revision=$(git rev-parse HEAD)" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,9 @@ RUN apk --update add git bzr openssh-client \
   && REPO_PATH="github.com/Financial-Times/content-preview" \
   && cd /content-preview/ \
   && GIT_URL="$(git config --get remote.origin.url)" \
-  && git clone $GIT_URL $GOPATH/src/${REPO_PATH} \
+  && GIT_BRANCH="$(git rev-parse --abbrev-ref HEAD)" \
+  && echo GIT_BRANCH \
+  && git clone $GIT_URL -b $GOPATH/src/${REPO_PATH} \
   && ls $GOPATH/src/${REPO_PATH} \
   && cd $GOPATH/src/${REPO_PATH} \
   && go get -t ./... \
@@ -18,7 +20,7 @@ RUN apk --update add git bzr openssh-client \
   && echo $VERSION \
   && DATETIME="dateTime=$(date -u +%Y%m%d%H%M%S)" \
   && echo $DATETIME \
-  && REPOSITORY="repository=$(git config --get remote.origin.url)" \
+  && REPOSITORY="repository=$GIT_URL" \
   && echo $REPOSITORY \
   && REVISION="revision=$(git rev-parse HEAD)" \
   && echo $REVISION \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN apk --update add bash git go \
   && export GOPATH=/gopath \
   && REPO_PATH="github.com/Financial-Times/content-preview" \
   && cd content-preview \
+  && git fetch --all \
   && BUILDINFO_PACKAGE="github.com/Financial-Times/service-status-go/buildinfo." \
   && VERSION="version=$(git describe --tag --always 2> /dev/null)" \
   && DATETIME="dateTime=$(date -u +%Y%m%d%H%M%S)" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,13 @@ FROM alpine:3.3
 
 ADD *.go *.txt .git /content-preview/
 
-RUN apk --update add git bzr \
+RUN apk --update add git bzr openssh-client \
   && apk --update add go \
   && export GOPATH=/gopath \
   && REPO_PATH="github.com/Financial-Times/content-preview" \
-  && git clone /content-preview/ $GOPATH/src/${REPO_PATH} \
+  && cd /content-preview/ \
+  && GIT_URL="$(git config --get remote.origin.url)" \
+  && git clone $GIT_URL $GOPATH/src/${REPO_PATH} \
   && ls $GOPATH/src/${REPO_PATH} \
   && cd $GOPATH/src/${REPO_PATH} \
   && git fetch \
@@ -27,7 +29,7 @@ RUN apk --update add git bzr \
   && echo ${LDFLAGS} \
   && go build -ldflags="${LDFLAGS}" \
   && mv content-preview /content-preview-app \
-  && apk del go git bzr \
+  && apk del go git bzr openssh-client \
   && rm -rf $GOPATH /var/cache/apk/*
 
 CMD exec /content-preview-app \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,6 @@ RUN apk --update add git bzr \
   && GIT_URL="$(git config --get remote.origin.url)" \
   && GIT_BRANCH="$(git rev-parse --abbrev-ref HEAD)" \
   && git clone -b $GIT_BRANCH $GIT_URL $GOPATH/src/${REPO_PATH} \
-  && ls $GOPATH/src/${REPO_PATH} \
   && cd $GOPATH/src/${REPO_PATH} \
   && go get -t ./... \
   && go test ./... \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,12 @@ ADD *.go *.txt .git /content-preview/
 
 RUN apk --update add git bzr \
   && apk --update add go \
-  && cd content-preview \
+  && export GOPATH=/gopath \
+  && REPO_PATH="github.com/Financial-Times/content-preview" \
+  && git clone /content-preview/ $GOPATH/src/${REPO_PATH} \
+  && cd $GOPATH/src/${REPO_PATH} \
+  && go get -t ./... \
+  && go test ./... \
   && BUILDINFO_PACKAGE="github.com/Financial-Times/service-status-go/buildinfo." \
   && VERSION="version=$(git describe --tag 2> /dev/null)" \
   && DATETIME="dateTime=$(date -u +%Y%m%d%H%M%S)" \
@@ -12,13 +17,6 @@ RUN apk --update add git bzr \
   && REVISION="revision=$(git rev-parse HEAD)" \
   && BUILDER="builder=$(go version)" \
   && LDFLAGS="-X '"${BUILDINFO_PACKAGE}$VERSION"' -X '"${BUILDINFO_PACKAGE}$DATETIME"' -X '"${BUILDINFO_PACKAGE}$REPOSITORY"' -X '"${BUILDINFO_PACKAGE}$REVISION"' -X '"${BUILDINFO_PACKAGE}$BUILDER"'" \
-  && export GOPATH=/gopath \
-  && REPO_PATH="github.com/Financial-Times/content-preview" \
-  && mkdir -p $GOPATH/src/${REPO_PATH} \
-  && mv * $GOPATH/src/${REPO_PATH} \
-  && cd $GOPATH/src/${REPO_PATH} \
-  && go get -t ./... \
-  && go test ./... \
   && echo ${LDFLAGS} \
   && go build -ldflags="${LDFLAGS}" \
   && mv content-preview /content-preview-app \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.3
 
-ADD *.go *.txt .git /content-preview/
+ADD *.go .git /content-preview/
 
 RUN apk --update add git bzr \
   && apk --update add go \


### PR DESCRIPTION
To fetch the missing git information, the Dockerfile clones the project from remote.
