### PR TITLE
Handle 422 status code from mapper.

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -85,6 +85,9 @@ func (h ContentHandler) handleResponse(req *http.Request, extResp *http.Response
 	case http.StatusNotFound:
 		h.handleNotFound(w, extResp, h.serviceConfig.transformAppName, req.URL.String(), uuid)
 		return false, nil
+	case 422:
+		h.handleUnprocessableEntity(w, extResp, h.serviceConfig.transformAppName, req.URL.String(), uuid)
+		return false, nil
 	default:
 		h.handleFailedRequest(w, extResp, h.serviceConfig.transformAppName, req.URL.String(), uuid)
 		return false, nil
@@ -105,6 +108,12 @@ func (h ContentHandler) handleFailedRequest(w http.ResponseWriter, resp *http.Re
 
 func (h ContentHandler) handleNotFound(w http.ResponseWriter, resp *http.Response, serviceName string, url string, uuid string) {
 	w.WriteHeader(http.StatusNotFound)
+	h.log.RequestFailedEvent(serviceName, url, resp, uuid)
+	h.metrics.recordRequestFailedEvent()
+}
+
+func (h ContentHandler) handleUnprocessableEntity(w http.ResponseWriter, resp *http.Response, serviceName string, url string, uuid string) {
+	w.WriteHeader(422)
 	h.log.RequestFailedEvent(serviceName, url, resp, uuid)
 	h.metrics.recordRequestFailedEvent()
 }


### PR DESCRIPTION
This is needed for internal content flow, because internal-components-preview (which uses this codebase) gets a 422 response code from methode-internal-components-mapper if there are no internal-components on the article requested (which is to be expected, because not all articles have internal-components). So right now, for this case the preview service would return 503 to the requester if he gets a 422 response from the mapper, which is not really good for logging, though it doesn't break our /internalcontent-preview endpoint that ignores internal-components if the response is bad from internal-components-preview.